### PR TITLE
Add Taints on Startup

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.1.2
+version: v0.2.0

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -127,3 +127,38 @@ Workload pool names.
 {{- define "openstack.discriminator.workload" -}}
 {{ (dict "openstack" $.values.openstack "pool" .pool) | mustToJson | sha256sum | trunc 8 }}
 {{- end }}
+
+{{/*
+Taints
+*/}}
+{{- define "openstack.taints.control-plane" -}}
+- key: node-role.kubernetes.io/master
+  effect: NoSchedule
+- key: node-role.kubernetes.io/control-plane
+  effect: NoSchedule
+{{- with $cluster := .Values.cluster }}
+{{- with $taints := $cluster.taints }}
+{{- range $taint := $taints }}
+- key: {{ $taint.key }}
+  effect: {{ $taint.effect }}
+{{- if .value }}
+  value: '{{ $taint.value }}'
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "openstack.taints.workload" -}}
+{{- with $cluster := .Values.cluster }}
+{{- with $taints := $cluster.taints }}
+{{- range $taint := $taints }}
+- key: {{ $taint.key }}
+  effect: {{ $taint.effect }}
+{{- if .value }}
+  value: '{{ $taint.value }}'
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
 spec:
+  version: "{{ .Values.controlPlane.version }}"
   replicas: {{ .Values.controlPlane.replicas }}
   machineTemplate:
     infrastructureRef:
@@ -19,6 +20,16 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
+        taints:
+          {{- include "openstack.taints.control-plane" . | nindent 8 }}
+    joinConfiguration:
+      nodeRegistration:
+        name: {{ "'{{ local_hostname }}'" }}
+        kubeletExtraArgs:
+          cloud-provider: external
+          node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
+        taints:
+          {{- include "openstack.taints.control-plane" . | nindent 8 }}
     clusterConfiguration:
       apiServer:
         extraArgs:
@@ -44,13 +55,6 @@ spec:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
-    joinConfiguration:
-      nodeRegistration:
-        name: {{ "'{{ local_hostname }}'" }}
-        kubeletExtraArgs:
-          cloud-provider: external
-          node-labels: {{- include "openstack.nodelabels.control-plane" . | nindent 12 }}
-  version: "{{ .Values.controlPlane.version }}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
 kind: OpenStackMachineTemplate

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -86,4 +86,6 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             node-labels: {{- include "openstack.nodelabels.workload" $context | nindent 14 }}
+          taints:
+            {{- include "openstack.taints.workload" $ | nindent 10 }}
 {{- end }}

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -60,6 +60,30 @@
 			"type": "string",
 			"pattern": "v\\d+\\.\\d+\\.\\d+"
 		},
+		"taint": {
+			"type": "object",
+			"required": [
+				"key",
+				"effect"
+			],
+			"properties": {
+				"key": {
+					"type": "string"
+				},
+				"effect": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				}
+			}
+		},
+		"taintList": {
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/taint"
+			}
+		},
 		"machineSet": {
 			"type": "object",
 			"required": [
@@ -206,6 +230,14 @@
                                 "failureDomain": {
                                         "type": "string"
                                 }
+			}
+		},
+		"cluster": {
+			"type": "object",
+			"properties": {
+				"taints": {
+					"$ref": "#/$defs/taintList"
+				}
 			}
 		},
 		"api": {

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -31,6 +31,15 @@ openstack:
   # present.  Control plane nodes are deployed in this failure domain.
   failureDomain: nova
 
+# Cluster wide configuration.
+cluster:
+  # Applies taints to all nodes e.g.
+  #
+  # taints:
+  # - key: node.cilium.io/agent-not-ready
+  #   effect: NoSchedule
+  #   value: 'true'
+
 # Kubernetes API specific configuration.
 # Modifications to this object will trigger a control plane upgrade.
 api:


### PR DESCRIPTION
This prevents CoreDNS coming up and needing a restart until Cilium is installed to initialize the CNI.