### PR TITLE
Fix Release Noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,3 +20,4 @@ jobs:
       uses: helm/chart-releaser-action@v1.4.1
       env:
         CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CR_SKIP_EXISTING: 'true'


### PR DESCRIPTION
It spots changes with every commit and tries to upload without figuring out there is already a release.  Make existing releases, with changes, not error.