### PR TITLE
Remove API Defaults

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.2.0
+version: v0.2.1

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -45,15 +45,15 @@ cluster:
 api:
   # Allow only the selected network address prefixes access to the API.
   #
-  allowList:
-  - 192.168.0.1/24
+  # allowList:
+  # - 192.168.0.1/24
 
   # Generate the API server certificate with a specific set of X.509
   # subject alternative names, "localhost" and "127.0.0.1" are required
   # by Kubernetes and added by default.
   #
-  certificateSANs:
-  - foo.acme.com
+  # certificateSANs:
+  # - foo.acme.com
 
 # Control plane topology.
 # Modifications to this object will trigger a control plane upgrade.


### PR DESCRIPTION
Because values.yamls are merged, we need to remove things that shoulfn't be there by default, as they will need manually disabling, which is a mare.