### PR TITLE
Fix Autoscaling

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.6
+version: v0.3.7
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -23,7 +23,9 @@ metadata:
     {{- include "openstackcluster.autoscalingAnnotations" $pool | nindent 4 }}
 spec:
   clusterName: "{{ $.Release.Name }}"
+  {{- if $pool.autoscaling }}{{ else }}
   replicas: {{ $pool.replicas }}
+  {{- end }}
   selector:
     matchLabels:
   template:


### PR DESCRIPTION
The observation is cluster autoscaler tries to scale down, and does so, however Argo does a refresh at some point and resets the replicas to their initial version (even whem ignored by the diff), which then scales back up again.  CAPI does some weird stuff too that they won't fix to compound the issue.  So, when using AS, don't set the field at all, leave it do defaulting and the auto scaler to remove the split brain entirely.