### PR TITLE
Separate Nova and Cinder AZs

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.8
+version: v0.3.9
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -73,8 +73,15 @@ capacity.cluster-autoscaler.kubernetes.io/gpu-count: '{{ $gpu.count }}'
 {{/*
 Workload failure domain.
 */}}
-{{- define "openstack.failureDomain.workload" -}}
-{{ .pool.machine.failureDomain | default .values.openstack.failureDomain }}
+{{- define "openstack.failureDomain.compute.workload" -}}
+{{ .pool.machine.failureDomain | default .values.openstack.computeFailureDomain }}
+{{- end }}
+
+{{/*
+Workload volume failure domain.
+*/}}
+{{- define "openstack.failureDomain.volume.workload" -}}
+{{ .pool.machine.disk.failureDomain | default .values.openstack.volumeFailureDomain }}
 {{- end }}
 
 {{/*

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -48,6 +48,8 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
+  controlPlaneAvailabilityZones:
+  - {{ .Values.openstack.computeFailureDomain }}
   managedSecurityGroups: true
   allowAllInClusterTraffic: true
   nodeCidr: {{ .Values.network.nodeCIDR }}

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -74,8 +74,8 @@ spec:
       identityRef:
         name: {{ .Release.Name }}-cloud-config
         kind: Secret
-      {{- if .Values.controlPlane.machine.diskSize }}
+      {{- if .Values.controlPlane.machine.disk }}
       rootVolume:
-        availabilityZone: {{ .Values.openstack.failureDomain }}
-        diskSize: {{ .Values.controlPlane.machine.diskSize }}
+        availabilityZone: {{ .Values.openstack.volumeFailureDomain }}
+        diskSize: {{ .Values.controlPlane.machine.disk.size }}
       {{- end }}

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       clusterName: "{{ $.Release.Name }}"
       version: "{{ $pool.version }}"
-      failureDomain: {{ include "openstack.failureDomain.workload" $context }}
+      failureDomain: {{ include "openstack.failureDomain.compute.workload" $context }}
       bootstrap:
         configRef:
           name: {{ $pool_name_discriminated }}
@@ -61,10 +61,10 @@ spec:
       {{- if $.Values.openstack.sshKeyName }}
       sshKeyName: {{ $.Values.openstack.sshKeyName }}
       {{- end }}
-      {{- if $pool.machine.diskSize }}
+      {{- with $disk := $pool.machine.disk }}
       rootVolume:
-        availabilityZone: {{ include "openstack.failureDomain.workload" $context }}
-        diskSize: {{ $pool.machine.diskSize }}
+        availabilityZone: {{ include "openstack.failureDomain.volume.workload" $context }}
+        diskSize: {{ $disk.size }}
       {{- end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -84,6 +84,20 @@
 				"$ref": "#/$defs/taint"
 			}
 		},
+		"disk": {
+			"type": "object",
+			"required": [
+				"size"
+			],
+			"properties": {
+				"size": {
+					"$ref": "#/$defs/nonNegativeNumber"
+				},
+				"failureDomain": {
+                                        "type": "string"
+                                }
+			}
+		},
 		"machine": {
 			"type": "object",
 			"required": [
@@ -97,8 +111,8 @@
 				"flavor": {
                                         "type": "string"
                                 },
-                                "diskSize": {
-                                        "$ref": "#/$defs/nonNegativeNumber"
+                                "disk": {
+                                        "$ref": "#/$defs/disk"
                                 },
 				"failureDomain": {
 					"type": "string"
@@ -217,7 +231,7 @@
 				"cloudsYAML",
 				"externalNetworkID",
 				"ca",
-				"failureDomain"
+				"computeFailureDomain"
 			],
 			"properties": {
 				"cloud": {
@@ -235,9 +249,12 @@
                                 "sshKeyName": {
                                         "type": "string"
                                 },
-                                "failureDomain": {
+                                "computeFailureDomain": {
                                         "type": "string"
-                                }
+                                },
+				"volumeFailureDomain": {
+					"type": "string"
+				}
 			}
 		},
 		"cluster": {

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -21,10 +21,14 @@ openstack:
   #
   # sshKeyName: foo
 
-  # Global failure domain name.  Workload pools can be distributed
+  # Compute failure domain name.  Workload pools can be distributed
   # across multiple failure domains, but default to this if not
   # present.  Control plane nodes are deployed in this failure domain.
-  failureDomain: nova
+  computeFailureDomain: nova
+
+  # If volumes are defined for machine sets, this is the global default.
+  # It can be overidden on a per-workload pool/control plane basis.
+  # volumeFailureDomain: nova
 
 # Cluster wide configuration.
 #
@@ -70,7 +74,7 @@ controlPlane:
 
     # Ephemeral disk size in GB.  If specified this overrides the default
     # size for the flavor.
-    diskSize: 80
+    # diskSize: 80
 
 # Workload pools topology.
 # workloadPools:


### PR DESCRIPTION
When you specify "nova" for our environment, it resolves down to another AZ.  Sadly, there is no AZ called that for cinder, so provisioning fails.  Make the different AZs separate and explicit.