### PR TITLE
Make Clusters Kinda Mutable

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.9
+version: v0.3.10
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -125,18 +125,29 @@ take a whole object and marshal it.
 {{- with $api := .Values.api }}
 {{- $value = set $value "certificateSANs" $api.certificateSANs }}
 {{- end }}
-{{ $value | mustToJson | sha256sum }}
+{{- $value | mustToJson | sha256sum }}
 {{- end }}
 
 {{- define "openstack.discriminator.control-plane" -}}
-{{ (dict "api" (include "openstack.discriminator.control-plane.api" .) "pool" .Values.controlPlane.machine) | mustToJson | sha256sum | trunc 8 }}
+{{- (dict "api" (include "openstack.discriminator.control-plane.api" .) "pool" .Values.controlPlane.machine) | mustToJson | sha256sum | trunc 8 }}
+{{- end }}
+
+{{/*
+Cluster name.
+*/}}
+{{- define "openstack.discriminator.cluster" -}}
+{{- $value := dict }}
+{{- with $api := .Values.api }}
+{{- $value = set $value "allowList" $api.allowList }}
+{{- end }}
+{{- $value | mustToJson | sha256sum | trunc 8 }}
 {{- end }}
 
 {{/*
 Workload pool names.
 */}}
 {{- define "openstack.discriminator.workload" -}}
-{{ (dict "pool" .pool.machine) | mustToJson | sha256sum | trunc 8 }}
+{{- (dict "pool" .pool.machine) | mustToJson | sha256sum | trunc 8 }}
 {{- end }}
 
 {{/*

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -1,3 +1,4 @@
+{{ $cluster_name_discriminated := printf "%v-%v" $.Release.Name (include "openstack.discriminator.cluster" .) }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -21,7 +22,7 @@ spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
     kind: OpenStackCluster
-    name: {{ .Release.Name }}
+    name: {{ $cluster_name_discriminated }}
   controlPlaneRef:
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -30,7 +31,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackCluster
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $cluster_name_discriminated }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Allow the firewall rules to be updated and thus trigger a rename of the cluster resource (which is immutable).  Everything else is immutable still.  In future, if the resource changes outside of user input, we'll need a way to trigger a rename.  Perhaps a manually defined revision or something that is bumped by the developer.