### PR TITLE
Handle CAPO Brokeness

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.11
+version: v0.3.12
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -133,13 +133,6 @@ take a whole object and marshal it.
 {{- end }}
 
 {{/*
-Cluster name.
-*/}}
-{{- define "openstack.discriminator.cluster" -}}
-{{- (dict "revision" .) | mustToJson | sha256sum | trunc 8 }}
-{{- end }}
-
-{{/*
 Workload pool names.
 */}}
 {{- define "openstack.discriminator.workload" -}}

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -1,14 +1,3 @@
-# The openstackcluster resource is immutable, with the exception of the
-# firewall rules list.  If anything else changes, then we need to trigger
-# an upgrade via a resource rename.  Like other things e.g. osmts, we can
-# base the name on inputs.  However in this case, something like adding
-# availability zone support (which should in general be immutable), would
-# also need to trigger a rename.  So to do that without making it based on
-# the input, we need another method, i.e. a revision.  So if you decide to
-# add support for a new immutable thing, you will also need to increment
-# this number.  Got it??
-{{- $cluster_revision := 1 }}
-{{- $cluster_name_discriminated := printf "%v-%v" $.Release.Name (include "openstack.discriminator.cluster" $cluster_revision) }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -32,18 +21,16 @@ spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
     kind: OpenStackCluster
-    name: {{ $cluster_name_discriminated }}
+    name: {{ .Release.Name }}
   controlPlaneRef:
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: {{ .Release.Name }}-control-plane
 ---
-# Please read the comment at the top of this file before making any changes
-# to this template.
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackCluster
 metadata:
-  name: {{ $cluster_name_discriminated }}
+  name: {{ .Release.Name }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
 spec:
@@ -61,8 +48,6 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-  controlPlaneAvailabilityZones:
-  - {{ .Values.openstack.computeFailureDomain }}
   managedSecurityGroups: true
   allowAllInClusterTraffic: true
   nodeCidr: {{ .Values.network.nodeCIDR }}


### PR DESCRIPTION
Adding in the control plane failure domains caused upgrade failures because the osc resource is immutable (with the exception of the firewall rules).  We tried to just change the name and the reference as per osmts etc.  This however failed quite dramatically because CAPO decides to get a new IP address for the API, which will break everything due to contact with the cluster vanishing.  However while it's doing this, it's constantly allocating floating IPs and failing to apply them due to one already existing.  So this reverts the original change that led to this mess.