### PR TITLE
Enforce Deprovisioning Order

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.12
+version: v0.3.13
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
+  annotations:
+    # If we just delete all the things, I believe there is a race where
+    # CAPO blows away the cluster infrastructure before it has a chance
+    # to delete the machines, and we get into a deadlock state.  By
+    # provisioning the cluster last, and deleting it first, we should be
+    # able to let CAPI take care of its own ordering.
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterNetwork:
     pods:

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -20,6 +20,10 @@ metadata:
   labels:
     {{- include "openstackcluster.labels" $ | nindent 4 }}
   annotations:
+    # See comment in cluster.yaml.  ArgoCD has some smarts that monitor
+    # the status of Cluster/Machine/MachineDeployment, so we need to
+    # provision this after any referenced templates.
+    argocd.argoproj.io/sync-wave: "2"
     {{- include "openstackcluster.autoscalingAnnotations" $pool | nindent 4 }}
 spec:
   clusterName: "{{ $.Release.Name }}"


### PR DESCRIPTION
Let CAPI be the ultimate thing that defines deletion order of child resources, not ArgoCD.