### PR TITLE
Remove Slavery References

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.13
+version: v0.3.14
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -143,8 +143,6 @@ Workload pool names.
 Taints
 */}}
 {{- define "openstack.taints.control-plane" -}}
-- key: node-role.kubernetes.io/master
-  effect: NoSchedule
 - key: node-role.kubernetes.io/control-plane
   effect: NoSchedule
 {{- with $cluster := .Values.cluster }}


### PR DESCRIPTION
Evidently "master" can now only be used by Star Wars, and has been deprecated in favour of control-plane.  In removing this taint, it should be possible for the default coredns deployment to get scheduled on CP nodes and facilitate scale to zero.