### PR TITLE
Add Autoscaler Side-Chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ CHARTS = cluster-api-core \
 # These charts are hand crafted, but still valid for things like
 # validation.
 USER_CHARTS = cluster-api \
-	      cluster-api-cluster-openstack
+	      cluster-api-cluster-openstack \
+	      cluster-api-cluster-autoscaler-openstack
 
 # Generator script location.
 GENERATE = ./generate.py

--- a/charts/cluster-api-cluster-autoscaler-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-autoscaler-openstack/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cluster-api-cluster-autoscaler-openstack
+description: A Helm chart to deploy autoscaler configuration for a Kubernetes Cluster
+type: application
+version: v0.1.0
+icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-autoscaler-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-autoscaler-openstack/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openstackcluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openstackcluster.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openstackcluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openstackcluster.labels" -}}
+helm.sh/chart: {{ include "openstackcluster.chart" . }}
+{{ include "openstackcluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openstackcluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openstackcluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/cluster-api-cluster-autoscaler-openstack/templates/clusterrole.yaml
+++ b/charts/cluster-api-cluster-autoscaler-openstack/templates/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "openstackcluster.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - openstackmachinetemplates
+  verbs:
+  - get
+  - list

--- a/charts/cluster-api-cluster-autoscaler-openstack/templates/clusterrolebinding.yaml
+++ b/charts/cluster-api-cluster-autoscaler-openstack/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "openstackcluster.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/cluster-api-cluster-autoscaler-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-autoscaler-openstack/values.schema.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"required": [
+		"serviceAccountName"
+	],
+	"properties": {
+		"serviceAccountName": {
+			"type": "string"
+		}
+	}
+}

--- a/charts/cluster-api-cluster-autoscaler-openstack/values.yaml
+++ b/charts/cluster-api-cluster-autoscaler-openstack/values.yaml
@@ -1,0 +1,2 @@
+# You'll want to force rbac.serviceAccount.name in the cluster-autoscaler chart to this value.
+serviceAccountName: cluster-autoscaler


### PR DESCRIPTION
While the community want this functionality (justifiably) in the main chart, as that's the thing that brings in the dependency, the maintainers (justifiably) don't want platform specific stuff in there. So rather than battel against the current, or have thousands of users fork and maintain the required bit, provide them in a centralized chart. That way you're not worried about forks, just this and the main branch.