### PR TITLE
patch: add a bind address for the controller

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.24
+version: v0.3.25
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -50,6 +50,7 @@ spec:
       controllerManager:
         extraArgs:
           cloud-provider: external
+          bind-address: "0.0.0.0"
       etcd:
         local:
           extraArgs:


### PR DESCRIPTION
This just adds a bind address for the controllerManager so that we can achieve metrics gathering on it.

https://prometheus-operator.dev/docs/kube/kube-prometheus-on-kubeadm/#kubeadm-pre-requisites