### PR TITLE
Fix Name Lengths

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.18
+version: v0.3.19
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "cluster.name" . }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
 spec:
@@ -21,16 +21,16 @@ spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
     kind: OpenStackCluster
-    name: {{ .Release.Name }}
+    name: {{ include "openstackcluster.name" . }}
   controlPlaneRef:
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    name: {{ .Release.Name }}-control-plane
+    name: {{ include "kubeadmcontrolplane.name" . }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackCluster
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "openstackcluster.name" . }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
   annotations:
@@ -39,7 +39,7 @@ metadata:
 spec:
   cloudName: {{ .Values.openstack.cloud }}
   identityRef:
-    name: {{ .Release.Name }}-cloud-config
+    name: {{ include "cloudconfig.name" . }}
     kind: Secret
   apiServerLoadBalancer:
     enabled: true
@@ -63,7 +63,7 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-cloud-config
+  name: {{ include "cloudconfig.name" . }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
     clusterctl.cluster.x-k8s.io/move: "true"

--- a/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/control-plane.yaml
@@ -2,7 +2,7 @@
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: "{{ .Release.Name }}-control-plane"
+  name: {{ include "kubeadmcontrolplane.name" . }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
   annotations:
@@ -15,7 +15,7 @@ spec:
     infrastructureRef:
       kind: OpenStackMachineTemplate
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
-      name: {{ .Release.Name }}-control-plane-{{ include "openstack.discriminator.control-plane" . }}
+      name: {{ include "controlplane.openstackmachinetemplate.name" . }}
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
@@ -62,7 +62,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha6
 kind: OpenStackMachineTemplate
 metadata:
-  name: {{ .Release.Name }}-control-plane-{{ include "openstack.discriminator.control-plane" . }}
+  name: {{ include "controlplane.openstackmachinetemplate.name" . }}
   labels:
     {{- include "openstackcluster.labels" . | nindent 4 }}
   annotations:
@@ -78,7 +78,7 @@ spec:
       {{- end }}
       cloudName: {{ .Values.openstack.cloud }}
       identityRef:
-        name: {{ .Release.Name }}-cloud-config
+        name: {{ include "cloudconfig.name" . }}
         kind: Secret
       {{- if .Values.controlPlane.machine.disk }}
       rootVolume:

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -1,17 +1,22 @@
-{{ $values := .Values }}
-{{ range $name, $pool := .Values.workloadPools }}
+{{- $values := .Values }}
+{{- range $name, $pool := .Values.workloadPools }}
 
 {{/*
 Helm is a bit crap in that $. doesn't work in an include with a non-global scope.
 To combat this, we build a custom context before handing off to thte template.
 */}}
-{{ $context := dict "name" $name "pool" $pool "values" $values }}
+{{- $context := dict "name" $name "pool" $pool "values" $values }}
 
 {{/*
 The resource names are common all over the place, so define in a canonical location.
 */}}
-{{ $pool_name := printf "%v-pool-%v" $.Release.Name $name }}
-{{ $pool_name_discriminated := printf "%v-pool-%v-%v" $.Release.Name $name (include "openstack.discriminator.workload" $context) }}
+{{- $pool_name := printf "cluster-%s-pool-%s" ( include "release.hash" $ ) ( $name | sha256sum | trunc 8 ) }}
+{{- $pool_name_discriminated := printf "cluster-%s-pool-%s-%s" ( include "release.hash" $ ) ( $name | sha256sum | trunc 8 ) ( include "openstack.discriminator.workload" $context ) }}
+
+{{- if $values.legacyResourceNames }}
+  {{- $pool_name = printf "%v-pool-%v" $.Release.Name $name }}
+  {{- $pool_name_discriminated = printf "%v-pool-%v-%v" $.Release.Name $name (include "openstack.discriminator.workload" $context) }}
+{{- end }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -24,7 +29,7 @@ metadata:
     argocd.argoproj.io/sync-options: Delete=false
     {{- include "openstackcluster.autoscalingAnnotations" $pool | nindent 4 }}
 spec:
-  clusterName: "{{ $.Release.Name }}"
+  clusterName: {{ include "cluster.name" $ }}
   {{- if not $pool.autoscaling }}
   replicas: {{ $pool.replicas }}
   {{- end }}
@@ -32,7 +37,7 @@ spec:
     matchLabels:
   template:
     spec:
-      clusterName: "{{ $.Release.Name }}"
+      clusterName: {{ include "cluster.name" $ }}
       version: "{{ $pool.version }}"
       failureDomain: {{ include "openstack.failureDomain.compute.workload" $context }}
       bootstrap:
@@ -59,7 +64,7 @@ spec:
     spec:
       cloudName: {{ $.Values.openstack.cloud }}
       identityRef:
-        name: {{ $.Release.Name }}-cloud-config
+        name: {{ include "cloudconfig.name" $ }}
         kind: Secret
       flavor: {{ $pool.machine.flavor }}
       image: {{ $pool.machine.image }}

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -227,6 +227,12 @@
 		"labelDomain": {
 			"type": "string"
 		},
+		"legacyResourceNames": {
+			"type": "boolean"
+		},
+		"controllerInstance": {
+			"type": "string"
+		},
 		"openstack": {
 			"type:": "object",
 			"required": [

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -1,6 +1,24 @@
 # Label domain for implicit labels defined in this chart.
 labelDomain: eschercloud.ai
 
+# We used to name everything based on the release name, but by doing that
+# we quite easily blew the 63 character limit, this enables that old behaviour.
+legacyResourceNames: false
+
+# CAPI instance that's creating the cluster.
+# Some providers expect only a single instance of CAPI to be controlling a
+# single cloud project.  If you have multiple instances, for example you
+# have a "development" and "production" CAPO, then names may alias due to
+# reuse across multiple instances.  Now depending on how broken the provider
+# is, if it goes on name alone you may get -- quite legitimately -- different
+# clusters using the same networks due to idempotentcy.  Where is goes badly
+# wrong is when the infrastructure provider looks at shared networks and
+# indiscrimately deletes all the things, thus deletion of one cluster can
+# cause deletion of another.  To solve this we allow a unique instance to be
+# injected so the names are different.  This is only applicable if
+# legacyResourceNames is set to false.
+controllerInstance: ""
+
 # OpenStack specific configuration.
 # Contains credentials for the cloud, networking options and other
 # Values in this object are considered immutable.


### PR DESCRIPTION
Some resources are made up of ${long name} plus some text, then a hash, then potentially another random value from apimachinery, so it's pretty easy to blow the 63 character limit.  Instead, hash things down to a sane size.