### PR TITLE
Upgrade CAPI to 1.4.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Update this for every tagged release.
-CHART_VERSION = v0.1.7
+CHART_VERSION = v0.1.8
 
 # Defines the versions to use for cluster API components.
-CAPI_VERSION = v1.3.2
+CAPI_VERSION = v1.4.3
 CAPO_VERSION = v0.7.1
 
 # All the charts we can generate.

--- a/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: v1.3.2
+appVersion: v1.4.3
 description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-bootstrap-kubeadm
 type: application
-version: v0.1.7
+version: v0.1.8

--- a/charts/cluster-api-bootstrap-kubeadm/crds/kubeadmconfigs.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/crds/kubeadmconfigs.bootstrap.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
     cluster.x-k8s.io/v1alpha3: v1alpha3
@@ -33,10 +33,12 @@ spec:
     singular: kubeadmconfig
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        description: "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1026,10 +1028,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        description: "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -2614,6 +2618,17 @@ spec:
                         items:
                           type: string
                         type: array
+                      imagePullPolicy:
+                        description: ImagePullPolicy specifies the policy for image
+                          pulling during kubeadm "init" and "join" operations. The
+                          value of this field must be one of "Always", "IfNotPresent"
+                          or "Never". Defaults to "IfNotPresent". This can be used
+                          only with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
                       kubeletExtraArgs:
                         additionalProperties:
                           type: string
@@ -2825,6 +2840,17 @@ spec:
                         items:
                           type: string
                         type: array
+                      imagePullPolicy:
+                        description: ImagePullPolicy specifies the policy for image
+                          pulling during kubeadm "init" and "join" operations. The
+                          value of this field must be one of "Always", "IfNotPresent"
+                          or "Never". Defaults to "IfNotPresent". This can be used
+                          only with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
                       kubeletExtraArgs:
                         additionalProperties:
                           type: string

--- a/charts/cluster-api-bootstrap-kubeadm/crds/kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/crds/kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
     cluster.x-k8s.io/v1alpha3: v1alpha3
@@ -33,11 +33,12 @@ spec:
     singular: kubeadmconfigtemplate
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
-          API.
+        description: "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1016,11 +1017,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
-          API.
+        description: "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -2023,6 +2025,27 @@ spec:
               template:
                 description: KubeadmConfigTemplateResource defines the Template structure.
                 properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
                   spec:
                     description: KubeadmConfigSpec defines the desired state of KubeadmConfig.
                       Either ClusterConfiguration and InitConfiguration should be
@@ -2644,6 +2667,18 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              imagePullPolicy:
+                                description: ImagePullPolicy specifies the policy
+                                  for image pulling during kubeadm "init" and "join"
+                                  operations. The value of this field must be one
+                                  of "Always", "IfNotPresent" or "Never". Defaults
+                                  to "IfNotPresent". This can be used only with Kubernetes
+                                  version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
                               kubeletExtraArgs:
                                 additionalProperties:
                                   type: string
@@ -2870,6 +2905,18 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              imagePullPolicy:
+                                description: ImagePullPolicy specifies the policy
+                                  for image pulling during kubeadm "init" and "join"
+                                  operations. The value of this field must be one
+                                  of "Always", "IfNotPresent" or "Never". Defaults
+                                  to "IfNotPresent". This can be used only with Kubernetes
+                                  version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
                               kubeletExtraArgs:
                                 additionalProperties:
                                   type: string

--- a/charts/cluster-api-bootstrap-kubeadm/templates/clusterrole-0.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/templates/clusterrole-0.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: bootstrap-kubeadm
   name: capi-kubeadm-bootstrap-manager-role

--- a/charts/cluster-api-bootstrap-kubeadm/templates/deployment-0.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/templates/deployment-0.yaml
@@ -22,7 +22,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=localhost:8080
-        - --feature-gates=MachinePool={{ .Values.exp_machine_pool }},KubeadmBootstrapFormatIgnition={{ .Values.exp_kubeadm_bootstrap_format_ignition }}
+        - --feature-gates=MachinePool={{ .Values.exp_machine_pool }},KubeadmBootstrapFormatIgnition={{ .Values.exp_kubeadm_bootstrap_format_ignition }},LazyRestmapper={{ .Values.exp_lazy_restmapper }}
         - --bootstrap-token-ttl={{ .Values.kubeadm_bootstrap_token_ttl }}
         - --logging-format=json
         command:
@@ -45,10 +45,22 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: capi-kubeadm-bootstrap-manager
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/charts/cluster-api-bootstrap-kubeadm/values.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/values.yaml
@@ -1,4 +1,5 @@
 exp_kubeadm_bootstrap_format_ignition: false
+exp_lazy_restmapper: false
 exp_machine_pool: false
-image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.2
+image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.4.3
 kubeadm_bootstrap_token_ttl: 15m

--- a/charts/cluster-api-control-plane-kubeadm/Chart.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: v1.3.2
+appVersion: v1.4.3
 description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-control-plane-kubeadm
 type: application
-version: v0.1.7
+version: v0.1.8

--- a/charts/cluster-api-control-plane-kubeadm/crds/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/crds/kubeadmcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: control-plane-kubeadm
     cluster.x-k8s.io/v1alpha3: v1alpha3
@@ -67,11 +67,12 @@ spec:
       jsonPath: .status.unavailableReplicas
       name: Unavailable
       type: integer
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
-          API.
+        description: "KubeadmControlPlane is the Schema for the KubeadmControlPlane\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1244,11 +1245,12 @@ spec:
       jsonPath: .status.unavailableReplicas
       name: Unavailable
       type: integer
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
-          API.
+        description: "KubeadmControlPlane is the Schema for the KubeadmControlPlane\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -3086,6 +3088,18 @@ spec:
                             items:
                               type: string
                             type: array
+                          imagePullPolicy:
+                            description: ImagePullPolicy specifies the policy for
+                              image pulling during kubeadm "init" and "join" operations.
+                              The value of this field must be one of "Always", "IfNotPresent"
+                              or "Never". Defaults to "IfNotPresent". This can be
+                              used only with Kubernetes version equal to 1.22 and
+                              later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
                           kubeletExtraArgs:
                             additionalProperties:
                               type: string
@@ -3306,6 +3320,18 @@ spec:
                             items:
                               type: string
                             type: array
+                          imagePullPolicy:
+                            description: ImagePullPolicy specifies the policy for
+                              image pulling during kubeadm "init" and "join" operations.
+                              The value of this field must be one of "Always", "IfNotPresent"
+                              or "Never". Defaults to "IfNotPresent". This can be
+                              used only with Kubernetes version equal to 1.22 and
+                              later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
                           kubeletExtraArgs:
                             additionalProperties:
                               type: string
@@ -3610,6 +3636,53 @@ spec:
                 required:
                 - infrastructureRef
                 type: object
+              remediationStrategy:
+                description: The RemediationStrategy that controls how control plane
+                  machine remediation happens.
+                properties:
+                  maxRetry:
+                    description: "MaxRetry is the Max number of retries while attempting\
+                      \ to remediate an unhealthy machine. A retry happens when a\
+                      \ machine that was created as a replacement for an unhealthy\
+                      \ machine also fails. For example, given a control plane with\
+                      \ three machines M1, M2, M3: \n M1 become unhealthy; remediation\
+                      \ happens, and M1-1 is created as a replacement. If M1-1 (replacement\
+                      \ of M1) has problems while bootstrapping it will become unhealthy,\
+                      \ and then be remediated; such operation is considered a retry,\
+                      \ remediation-retry #1. If M1-2 (replacement of M1-1) becomes\
+                      \ unhealthy, remediation-retry #2 will happen, etc. \n A retry\
+                      \ could happen only after RetryPeriod from the previous retry.\
+                      \ If a machine is marked as unhealthy after MinHealthyPeriod\
+                      \ from the previous remediation expired, this is not considered\
+                      \ a retry anymore because the new issue is assumed unrelated\
+                      \ from the previous one. \n If not set, the remedation will\
+                      \ be retried infinitely."
+                    format: int32
+                    type: integer
+                  minHealthyPeriod:
+                    description: "MinHealthyPeriod defines the duration after which\
+                      \ KCP will consider any failure to a machine unrelated from\
+                      \ the previous one. In this case the remediation is not considered\
+                      \ a retry anymore, and thus the retry counter restarts from\
+                      \ 0. For example, assuming MinHealthyPeriod is set to 1h (default)\
+                      \ \n M1 become unhealthy; remediation happens, and M1-1 is created\
+                      \ as a replacement. If M1-1 (replacement of M1) has problems\
+                      \ within the 1hr after the creation, also this machine will\
+                      \ be remediated and this operation is considered a retry - a\
+                      \ problem related to the original issue happened to M1 -. \n\
+                      \ If instead the problem on M1-1 is happening after MinHealthyPeriod\
+                      \ expired, e.g. four days after m1-1 has been created as a remediation\
+                      \ of M1, the problem on M1-1 is considered unrelated to the\
+                      \ original issue happened to M1. \n If not set, this value is\
+                      \ defaulted to 1h."
+                    type: string
+                  retryPeriod:
+                    description: "RetryPeriod is the duration that KCP should wait\
+                      \ before remediating a machine being created as a replacement\
+                      \ for an unhealthy machine (a retry). \n If not set, a retry\
+                      \ will happen immediately."
+                    type: string
+                type: object
               replicas:
                 description: Number of desired machines. Defaults to 1. When stacked
                   etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
@@ -3617,9 +3690,11 @@ spec:
                 format: int32
                 type: integer
               rolloutAfter:
-                description: RolloutAfter is a field to indicate a rollout should
+                description: 'RolloutAfter is a field to indicate a rollout should
                   be performed after the specified time even if no changes have been
-                  made to the KubeadmControlPlane.
+                  made to the KubeadmControlPlane. Example: In the YAML the time can
+                  be specified in the RFC3339 format. To specify the rolloutAfter
+                  target as March 9, 2023, at 9 am UTC use "2023-03-09T09:00:00Z".'
                 format: date-time
                 type: string
               rolloutBefore:
@@ -3736,6 +3811,30 @@ spec:
                 description: Initialized denotes whether or not the control plane
                   has the uploaded kubeadm-config configmap.
                 type: boolean
+              lastRemediation:
+                description: LastRemediation stores info about last remediation performed.
+                properties:
+                  machine:
+                    description: Machine is the machine name of the latest machine
+                      being remediated.
+                    type: string
+                  retryCount:
+                    description: RetryCount used to keep track of remediation retry
+                      for the last remediated machine. A retry happens when a machine
+                      that was created as a replacement for an unhealthy machine also
+                      fails.
+                    format: int32
+                    type: integer
+                  timestamp:
+                    description: Timestamp is when last remediation happened. It is
+                      represented in RFC3339 form and is in UTC.
+                    format: date-time
+                    type: string
+                required:
+                - machine
+                - retryCount
+                - timestamp
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed
                   by the controller.

--- a/charts/cluster-api-control-plane-kubeadm/crds/kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/crds/kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: control-plane-kubeadm
     cluster.x-k8s.io/v1alpha3: v1alpha3
@@ -38,11 +38,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
-          API.
+        description: "KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1223,6 +1224,27 @@ spec:
                 description: KubeadmControlPlaneTemplateResource describes the data
                   needed to create a KubeadmControlPlane from a template.
                 properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
                   spec:
                     description: 'KubeadmControlPlaneTemplateResourceSpec defines
                       the desired state of KubeadmControlPlane. NOTE: KubeadmControlPlaneTemplateResourceSpec
@@ -1876,6 +1898,19 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  imagePullPolicy:
+                                    description: ImagePullPolicy specifies the policy
+                                      for image pulling during kubeadm "init" and
+                                      "join" operations. The value of this field must
+                                      be one of "Always", "IfNotPresent" or "Never".
+                                      Defaults to "IfNotPresent". This can be used
+                                      only with Kubernetes version equal to 1.22 and
+                                      later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
                                   kubeletExtraArgs:
                                     additionalProperties:
                                       type: string
@@ -2112,6 +2147,19 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  imagePullPolicy:
+                                    description: ImagePullPolicy specifies the policy
+                                      for image pulling during kubeadm "init" and
+                                      "join" operations. The value of this field must
+                                      be one of "Always", "IfNotPresent" or "Never".
+                                      Defaults to "IfNotPresent". This can be used
+                                      only with Kubernetes version equal to 1.22 and
+                                      later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
                                   kubeletExtraArgs:
                                     additionalProperties:
                                       type: string
@@ -2347,6 +2395,28 @@ spec:
                           machines should be shaped when creating or updating a control
                           plane.
                         properties:
+                          metadata:
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value
+                                  map stored with a resource that may be set by external
+                                  tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: 'Map of string keys and values that can
+                                  be used to organize and categorize (scope and select)
+                                  objects. May match selectors of replication controllers
+                                  and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                            type: object
                           nodeDeletionTimeout:
                             description: NodeDeletionTimeout defines how long the
                               machine controller will attempt to delete the Node that
@@ -2368,6 +2438,57 @@ spec:
                               all volumes to be detached. The default value is 0,
                               meaning that the volumes can be detached without any
                               time limitations.
+                            type: string
+                        type: object
+                      remediationStrategy:
+                        description: The RemediationStrategy that controls how control
+                          plane machine remediation happens.
+                        properties:
+                          maxRetry:
+                            description: "MaxRetry is the Max number of retries while\
+                              \ attempting to remediate an unhealthy machine. A retry\
+                              \ happens when a machine that was created as a replacement\
+                              \ for an unhealthy machine also fails. For example,\
+                              \ given a control plane with three machines M1, M2,\
+                              \ M3: \n M1 become unhealthy; remediation happens, and\
+                              \ M1-1 is created as a replacement. If M1-1 (replacement\
+                              \ of M1) has problems while bootstrapping it will become\
+                              \ unhealthy, and then be remediated; such operation\
+                              \ is considered a retry, remediation-retry #1. If M1-2\
+                              \ (replacement of M1-1) becomes unhealthy, remediation-retry\
+                              \ #2 will happen, etc. \n A retry could happen only\
+                              \ after RetryPeriod from the previous retry. If a machine\
+                              \ is marked as unhealthy after MinHealthyPeriod from\
+                              \ the previous remediation expired, this is not considered\
+                              \ a retry anymore because the new issue is assumed unrelated\
+                              \ from the previous one. \n If not set, the remedation\
+                              \ will be retried infinitely."
+                            format: int32
+                            type: integer
+                          minHealthyPeriod:
+                            description: "MinHealthyPeriod defines the duration after\
+                              \ which KCP will consider any failure to a machine unrelated\
+                              \ from the previous one. In this case the remediation\
+                              \ is not considered a retry anymore, and thus the retry\
+                              \ counter restarts from 0. For example, assuming MinHealthyPeriod\
+                              \ is set to 1h (default) \n M1 become unhealthy; remediation\
+                              \ happens, and M1-1 is created as a replacement. If\
+                              \ M1-1 (replacement of M1) has problems within the 1hr\
+                              \ after the creation, also this machine will be remediated\
+                              \ and this operation is considered a retry - a problem\
+                              \ related to the original issue happened to M1 -. \n\
+                              \ If instead the problem on M1-1 is happening after\
+                              \ MinHealthyPeriod expired, e.g. four days after m1-1\
+                              \ has been created as a remediation of M1, the problem\
+                              \ on M1-1 is considered unrelated to the original issue\
+                              \ happened to M1. \n If not set, this value is defaulted\
+                              \ to 1h."
+                            type: string
+                          retryPeriod:
+                            description: "RetryPeriod is the duration that KCP should\
+                              \ wait before remediating a machine being created as\
+                              \ a replacement for an unhealthy machine (a retry).\
+                              \ \n If not set, a retry will happen immediately."
                             type: string
                         type: object
                       rolloutAfter:

--- a/charts/cluster-api-control-plane-kubeadm/templates/deployment-0.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/templates/deployment-0.yaml
@@ -22,7 +22,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=localhost:8080
-        - --feature-gates=ClusterTopology={{ .Values.cluster_topology }},KubeadmBootstrapFormatIgnition={{ .Values.exp_kubeadm_bootstrap_format_ignition }}
+        - --feature-gates=ClusterTopology={{ .Values.cluster_topology }},KubeadmBootstrapFormatIgnition={{ .Values.exp_kubeadm_bootstrap_format_ignition }},LazyRestmapper={{ .Values.exp_lazy_restmapper }}
         - --logging-format=json
         command:
         - /manager
@@ -57,10 +57,22 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: capi-kubeadm-control-plane-manager
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/charts/cluster-api-control-plane-kubeadm/values.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/values.yaml
@@ -1,3 +1,4 @@
 cluster_topology: false
 exp_kubeadm_bootstrap_format_ignition: false
-image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.2
+exp_lazy_restmapper: false
+image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.4.3

--- a/charts/cluster-api-core/Chart.yaml
+++ b/charts/cluster-api-core/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: v1.3.2
+appVersion: v1.4.3
 description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-core
 type: application
-version: v0.1.7
+version: v0.1.8

--- a/charts/cluster-api-core/crds/clusterclasses.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/clusterclasses.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: clusterclasses.cluster.x-k8s.io
@@ -37,11 +37,13 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterClass is a template which can be used to create managed
-          topologies.
+        description: "ClusterClass is a template which can be used to create managed\
+          \ topologies. \n Deprecated: This type will be removed in one of the next\
+          \ releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -573,8 +575,10 @@ spec:
                     - ref
                     type: object
                   metadata:
-                    description: "Metadata is the metadata applied to the machines\
-                      \ of the ControlPlane. At runtime this metadata is merged with\
+                    description: "Metadata is the metadata applied to the ControlPlane\
+                      \ and the Machines of the ControlPlane if the ControlPlaneTemplate\
+                      \ referenced is machine based. If not, it is applied only to\
+                      \ the ControlPlane. At runtime this metadata is merged with\
                       \ the corresponding metadata from the topology. \n This field\
                       \ is supported if and only if the control plane provider template\
                       \ referenced is Machine based."
@@ -844,10 +848,21 @@ spec:
                       description: 'External defines an external patch. Note: Exactly
                         one of Definitions or External must be set.'
                       properties:
+                        discoverVariablesExtension:
+                          description: DiscoverVariablesExtension references an extension
+                            which is called to discover variables.
+                          type: string
                         generateExtension:
                           description: GenerateExtension references an extension which
                             is called to generate patches.
                           type: string
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: Settings defines key value pairs to be passed
+                            to the extensions. Values defined here take precedence
+                            over the values defined in the corresponding ExtensionConfig.
+                          type: object
                         validateExtension:
                           description: ValidateExtension references an extension which
                             is called to validate the topology.
@@ -1363,9 +1378,9 @@ spec:
                               type: object
                             metadata:
                               description: Metadata is the metadata applied to the
-                                machines of the MachineDeployment. At runtime this
-                                metadata is merged with the corresponding metadata
-                                from the topology.
+                                MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding
+                                metadata from the topology.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1442,6 +1457,200 @@ spec:
                   - lastTransitionTime
                   - status
                   - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              variables:
+                description: Variables is a list of ClusterClassStatusVariable that
+                  are defined for the ClusterClass.
+                items:
+                  description: ClusterClassStatusVariable defines a variable which
+                    appears in the status of a ClusterClass.
+                  properties:
+                    definitions:
+                      description: Definitions is a list of definitions for a variable.
+                      items:
+                        description: ClusterClassStatusVariableDefinition defines
+                          a variable which appears in the status of a ClusterClass.
+                        properties:
+                          from:
+                            description: From specifies the origin of the variable
+                              definition. This will be `inline` for variables defined
+                              in the ClusterClass or the name of a patch defined in
+                              the ClusterClass for variables discovered from a DiscoverVariables
+                              runtime extensions.
+                            type: string
+                          required:
+                            description: 'Required specifies if the variable is required.
+                              Note: this applies to the variable as a whole and thus
+                              the top-level object defined in the schema. If nested
+                              fields are required, this will be specified inside the
+                              schema.'
+                            type: boolean
+                          schema:
+                            description: Schema defines the schema of the variable.
+                            properties:
+                              openAPIV3Schema:
+                                description: OpenAPIV3Schema defines the schema of
+                                  a variable via OpenAPI v3 schema. The schema is
+                                  a subset of the schema used in Kubernetes CRDs.
+                                properties:
+                                  additionalProperties:
+                                    description: 'AdditionalProperties specifies the
+                                      schema of values in a map (keys are always strings).
+                                      NOTE: Can only be set if type is object. NOTE:
+                                      AdditionalProperties is mutually exclusive with
+                                      Properties. NOTE: This field uses PreserveUnknownFields
+                                      and Schemaless, because recursive validation
+                                      is not possible.'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  default:
+                                    description: 'Default is the default value of
+                                      the variable. NOTE: Can be set for all types.'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: Description is a human-readable description
+                                      of this variable.
+                                    type: string
+                                  enum:
+                                    description: 'Enum is the list of valid values
+                                      of the variable. NOTE: Can be set for all types.'
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  example:
+                                    description: Example is an example for this variable.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  exclusiveMaximum:
+                                    description: 'ExclusiveMaximum specifies if the
+                                      Maximum is exclusive. NOTE: Can only be set
+                                      if type is integer or number.'
+                                    type: boolean
+                                  exclusiveMinimum:
+                                    description: 'ExclusiveMinimum specifies if the
+                                      Minimum is exclusive. NOTE: Can only be set
+                                      if type is integer or number.'
+                                    type: boolean
+                                  format:
+                                    description: 'Format is an OpenAPI v3 format string.
+                                      Unknown formats are ignored. For a list of supported
+                                      formats please see: (of the k8s.io/apiextensions-apiserver
+                                      version we''re currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                      NOTE: Can only be set if type is string.'
+                                    type: string
+                                  items:
+                                    description: 'Items specifies fields of an array.
+                                      NOTE: Can only be set if type is array. NOTE:
+                                      This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  maxItems:
+                                    description: 'MaxItems is the max length of an
+                                      array variable. NOTE: Can only be set if type
+                                      is array.'
+                                    format: int64
+                                    type: integer
+                                  maxLength:
+                                    description: 'MaxLength is the max length of a
+                                      string variable. NOTE: Can only be set if type
+                                      is string.'
+                                    format: int64
+                                    type: integer
+                                  maximum:
+                                    description: 'Maximum is the maximum of an integer
+                                      or number variable. If ExclusiveMaximum is false,
+                                      the variable is valid if it is lower than, or
+                                      equal to, the value of Maximum. If ExclusiveMaximum
+                                      is true, the variable is valid if it is strictly
+                                      lower than the value of Maximum. NOTE: Can only
+                                      be set if type is integer or number.'
+                                    format: int64
+                                    type: integer
+                                  minItems:
+                                    description: 'MinItems is the min length of an
+                                      array variable. NOTE: Can only be set if type
+                                      is array.'
+                                    format: int64
+                                    type: integer
+                                  minLength:
+                                    description: 'MinLength is the min length of a
+                                      string variable. NOTE: Can only be set if type
+                                      is string.'
+                                    format: int64
+                                    type: integer
+                                  minimum:
+                                    description: 'Minimum is the minimum of an integer
+                                      or number variable. If ExclusiveMinimum is false,
+                                      the variable is valid if it is greater than,
+                                      or equal to, the value of Minimum. If ExclusiveMinimum
+                                      is true, the variable is valid if it is strictly
+                                      greater than the value of Minimum. NOTE: Can
+                                      only be set if type is integer or number.'
+                                    format: int64
+                                    type: integer
+                                  pattern:
+                                    description: 'Pattern is the regex which a string
+                                      variable must match. NOTE: Can only be set if
+                                      type is string.'
+                                    type: string
+                                  properties:
+                                    description: 'Properties specifies fields of an
+                                      object. NOTE: Can only be set if type is object.
+                                      NOTE: Properties is mutually exclusive with
+                                      AdditionalProperties. NOTE: This field uses
+                                      PreserveUnknownFields and Schemaless, because
+                                      recursive validation is not possible.'
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                    description: 'Required specifies which fields
+                                      of an object are required. NOTE: Can only be
+                                      set if type is object.'
+                                    items:
+                                      type: string
+                                    type: array
+                                  type:
+                                    description: 'Type is the type of the variable.
+                                      Valid values are: object, array, string, integer,
+                                      number or boolean.'
+                                    type: string
+                                  uniqueItems:
+                                    description: 'UniqueItems specifies if items in
+                                      an array must be unique. NOTE: Can only be set
+                                      if type is array.'
+                                    type: boolean
+                                  x-kubernetes-preserve-unknown-fields:
+                                    description: XPreserveUnknownFields allows setting
+                                      fields in a variable object which are not defined
+                                      in the variable schema. This affects fields
+                                      recursively, except if nested properties or
+                                      additionalProperties are specified in the schema.
+                                    type: boolean
+                                required:
+                                - type
+                                type: object
+                            required:
+                            - openAPIV3Schema
+                            type: object
+                        required:
+                        - from
+                        - required
+                        - schema
+                        type: object
+                      type: array
+                    definitionsConflict:
+                      description: DefinitionsConflict specifies whether or not there
+                        are conflicting definitions for a single variable name.
+                      type: boolean
+                    name:
+                      description: Name is the name of the variable.
+                      type: string
+                  required:
+                  - definitions
+                  - name
                   type: object
                 type: array
             type: object

--- a/charts/cluster-api-core/crds/clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/clusterresourcesetbindings.addons.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: clusterresourcesetbindings.addons.cluster.x-k8s.io
@@ -30,11 +30,13 @@ spec:
     singular: clusterresourcesetbinding
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
-          with the cluster it belongs to.
+        description: "ClusterResourceSetBinding lists all matching ClusterResourceSets\
+          \ with the cluster it belongs to. \n Deprecated: This type will be removed\
+          \ in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -118,11 +120,13 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
-          with the cluster it belongs to.
+        description: "ClusterResourceSetBinding lists all matching ClusterResourceSets\
+          \ with the cluster it belongs to. \n Deprecated: This type will be removed\
+          \ in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -283,6 +287,10 @@ spec:
                   - clusterResourceSetName
                   type: object
                 type: array
+              clusterName:
+                description: 'ClusterName is the name of the Cluster this binding
+                  applies to. Note: this field mandatory in v1beta2.'
+                type: string
             type: object
         type: object
     served: true

--- a/charts/cluster-api-core/crds/clusterresourcesets.addons.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/clusterresourcesets.addons.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: clusterresourcesets.addons.cluster.x-k8s.io
@@ -30,11 +30,12 @@ spec:
     singular: clusterresourceset
   scope: Namespaced
   versions:
-  - name: v1alpha3
+  - deprecated: true
+    name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSet is the Schema for the clusterresourcesets
-          API.
+        description: "ClusterResourceSet is the Schema for the clusterresourcesets\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -192,11 +193,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSet is the Schema for the clusterresourcesets
-          API.
+        description: "ClusterResourceSet is the Schema for the clusterresourcesets\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -451,6 +453,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - Reconcile
                 type: string
             required:
             - clusterSelector

--- a/charts/cluster-api-core/crds/clusters.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/clusters.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: clusters.cluster.x-k8s.io
@@ -37,6 +37,7 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -298,10 +299,12 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: Cluster is the Schema for the clusters API.
+        description: "Cluster is the Schema for the clusters API. \n Deprecated: This\
+          \ type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -964,12 +967,12 @@ spec:
                             type: string
                         type: object
                       metadata:
-                        description: "Metadata is the metadata applied to the machines\
-                          \ of the ControlPlane. At runtime this metadata is merged\
-                          \ with the corresponding metadata from the ClusterClass.\
-                          \ \n This field is supported if and only if the control\
-                          \ plane provider template referenced in the ClusterClass\
-                          \ is Machine based."
+                        description: Metadata is the metadata applied to the ControlPlane
+                          and the Machines of the ControlPlane if the ControlPlaneTemplate
+                          referenced by the ClusterClass is machine based. If not,
+                          it is applied only to the ControlPlane. At runtime this
+                          metadata is merged with the corresponding metadata from
+                          the ClusterClass.
                         properties:
                           annotations:
                             additionalProperties:
@@ -1019,9 +1022,10 @@ spec:
                         type: integer
                     type: object
                   rolloutAfter:
-                    description: RolloutAfter performs a rollout of the entire cluster
+                    description: 'RolloutAfter performs a rollout of the entire cluster
                       one component at a time, control plane first and then machine
-                      deployments.
+                      deployments. Deprecated: This field has no function and is going
+                      to be removed in the next apiVersion.'
                     format: date-time
                     type: string
                   variables:
@@ -1030,9 +1034,18 @@ spec:
                       defined in the ClusterClass.
                     items:
                       description: ClusterVariable can be used to customize the Cluster
-                        through patches. It must comply to the corresponding ClusterClassVariable
-                        defined in the ClusterClass.
+                        through patches. Each ClusterVariable is associated with a
+                        Variable definition in the ClusterClass `status` variables.
                       properties:
+                        definitionFrom:
+                          description: 'DefinitionFrom specifies where the definition
+                            of this Variable is from. DefinitionFrom is `inline` when
+                            the definition is from the ClusterClass `.spec.variables`
+                            or the name of a patch defined in the ClusterClass `.spec.patches`
+                            where the patch is external and provides external variables.
+                            This field is mandatory if the variable has `DefinitionsConflict:
+                            true` in ClusterClass `status.variables[]`'
+                          type: string
                         name:
                           description: Name of the variable.
                           type: string
@@ -1203,9 +1216,9 @@ spec:
                               type: object
                             metadata:
                               description: Metadata is the metadata applied to the
-                                machines of the MachineDeployment. At runtime this
-                                metadata is merged with the corresponding metadata
-                                from the ClusterClass.
+                                MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding
+                                metadata from the ClusterClass.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1265,8 +1278,8 @@ spec:
                               description: Replicas is the number of worker nodes
                                 belonging to this set. If the value is nil, the MachineDeployment
                                 is created without the number of Replicas (defaulting
-                                to zero) and it's assumed that an external entity
-                                (like cluster autoscaler) is responsible for the management
+                                to 1) and it's assumed that an external entity (like
+                                cluster autoscaler) is responsible for the management
                                 of this value.
                               format: int32
                               type: integer
@@ -1348,10 +1361,21 @@ spec:
                                     level variables.
                                   items:
                                     description: ClusterVariable can be used to customize
-                                      the Cluster through patches. It must comply
-                                      to the corresponding ClusterClassVariable defined
-                                      in the ClusterClass.
+                                      the Cluster through patches. Each ClusterVariable
+                                      is associated with a Variable definition in
+                                      the ClusterClass `status` variables.
                                     properties:
+                                      definitionFrom:
+                                        description: 'DefinitionFrom specifies where
+                                          the definition of this Variable is from.
+                                          DefinitionFrom is `inline` when the definition
+                                          is from the ClusterClass `.spec.variables`
+                                          or the name of a patch defined in the ClusterClass
+                                          `.spec.patches` where the patch is external
+                                          and provides external variables. This field
+                                          is mandatory if the variable has `DefinitionsConflict:
+                                          true` in ClusterClass `status.variables[]`'
+                                        type: string
                                       name:
                                         description: Name of the variable.
                                         type: string

--- a/charts/cluster-api-core/crds/extensionconfigs.runtime.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/extensionconfigs.runtime.cluster.x-k8s.io.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: extensionconfigs.runtime.cluster.x-k8s.io
@@ -140,6 +139,13 @@ spec:
                       is "In", and the values array contains only "value". The requirements
                       are ANDed.
                     type: object
+                type: object
+              settings:
+                additionalProperties:
+                  type: string
+                description: 'Settings defines key value pairs to be passed to all
+                  calls to all supported RuntimeExtensions. Note: Settings can be
+                  overridden on the ClusterClass.'
                 type: object
             required:
             - clientConfig

--- a/charts/cluster-api-core/crds/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/ipaddressclaims.ipam.cluster.x-k8s.io.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: ipaddressclaims.ipam.cluster.x-k8s.io
@@ -128,8 +127,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - addressRef
             type: object
         type: object
     served: true

--- a/charts/cluster-api-core/crds/ipaddresses.ipam.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/ipaddresses.ipam.cluster.x-k8s.io.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: ipaddresses.ipam.cluster.x-k8s.io
@@ -94,7 +93,6 @@ spec:
             required:
             - address
             - claimRef
-            - gateway
             - poolRef
             - prefix
             type: object

--- a/charts/cluster-api-core/crds/machinedeployments.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/machinedeployments.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: machinedeployments.cluster.x-k8s.io
@@ -54,10 +54,12 @@ spec:
       jsonPath: .status.unavailableReplicas
       name: Unavailable
       type: integer
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineDeployment is the Schema for the machinedeployments API.
+        description: "MachineDeployment is the Schema for the machinedeployments API.\
+          \ \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -554,10 +556,12 @@ spec:
       jsonPath: .status.unavailableReplicas
       name: Unavailable
       type: integer
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineDeployment is the Schema for the machinedeployments API.
+        description: "MachineDeployment is the Schema for the machinedeployments API.\
+          \ \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1068,9 +1072,23 @@ spec:
                 format: int32
                 type: integer
               replicas:
-                default: 1
-                description: Number of desired machines. Defaults to 1. This is a
-                  pointer to distinguish between explicit zero and not specified.
+                description: "Number of desired machines. This is a pointer to distinguish\
+                  \ between explicit zero and not specified. \n Defaults to: * if\
+                  \ the Kubernetes autoscaler min size and max size annotations are\
+                  \ set: - if it's a new MachineDeployment, use min size - if the\
+                  \ replicas field of the old MachineDeployment is < min size, use\
+                  \ min size - if the replicas field of the old MachineDeployment\
+                  \ is > max size, use max size - if the replicas field of the old\
+                  \ MachineDeployment is in the (min size, max size) range, keep the\
+                  \ value from the oldMD * otherwise use 1 Note: Defaulting will be\
+                  \ run whenever the replicas field is not set: * A new MachineDeployment\
+                  \ is created with replicas not set. * On an existing MachineDeployment\
+                  \ the replicas field was first set and is now unset. Those cases\
+                  \ are especially relevant for the following Kubernetes autoscaler\
+                  \ use cases: * A new MachineDeployment is created and replicas should\
+                  \ be managed by the autoscaler * An existing MachineDeployment which\
+                  \ initially wasn't controlled by the autoscaler should be later\
+                  \ controlled by the autoscaler"
                 format: int32
                 type: integer
               revisionHistoryLimit:
@@ -1079,6 +1097,14 @@ spec:
                   Defaults to 1.
                 format: int32
                 type: integer
+              rolloutAfter:
+                description: 'RolloutAfter is a field to indicate a rollout should
+                  be performed after the specified time even if no changes have been
+                  made to the MachineDeployment. Example: In the YAML the time can
+                  be specified in the RFC3339 format. To specify the rolloutAfter
+                  target as March 9, 2023, at 9 am UTC use "2023-03-09T09:00:00Z".'
+                format: date-time
+                type: string
               selector:
                 description: Label selector for machines. Existing MachineSets whose
                   machines are selected by this will be the ones affected by this

--- a/charts/cluster-api-core/crds/machinehealthchecks.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/machinehealthchecks.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: machinehealthchecks.cluster.x-k8s.io
@@ -46,11 +46,12 @@ spec:
       jsonPath: .status.currentHealthy
       name: CurrentHealthy
       type: integer
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineHealthCheck is the Schema for the machinehealthchecks
-          API.
+        description: "MachineHealthCheck is the Schema for the machinehealthchecks\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -306,11 +307,12 @@ spec:
       jsonPath: .status.currentHealthy
       name: CurrentHealthy
       type: integer
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineHealthCheck is the Schema for the machinehealthchecks
-          API.
+        description: "MachineHealthCheck is the Schema for the machinehealthchecks\
+          \ API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/charts/cluster-api-core/crds/machinepools.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/machinepools.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: machinepools.cluster.x-k8s.io
@@ -46,10 +46,12 @@ spec:
       jsonPath: .spec.template.spec.version
       name: Version
       type: string
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachinePool is the Schema for the machinepools API.
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -597,10 +599,12 @@ spec:
       jsonPath: .spec.template.spec.version
       name: Version
       type: string
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachinePool is the Schema for the machinepools API.
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/charts/cluster-api-core/crds/machines.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/machines.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: machines.cluster.x-k8s.io
@@ -50,10 +50,12 @@ spec:
       name: NodeName
       priority: 1
       type: string
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: Machine is the Schema for the machines API.
+        description: "Machine is the Schema for the machines API. \n Deprecated: This\
+          \ type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -398,10 +400,12 @@ spec:
       name: NodeName
       priority: 1
       type: string
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: Machine is the Schema for the machines API.
+        description: "Machine is the Schema for the machines API. \n Deprecated: This\
+          \ type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -968,8 +972,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/charts/cluster-api-core/crds/machinesets.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-core/crds/machinesets.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: machinesets.cluster.x-k8s.io
@@ -45,10 +45,12 @@ spec:
       jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    deprecated: true
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineSet is the Schema for the machinesets API.
+        description: "MachineSet is the Schema for the machinesets API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -491,10 +493,12 @@ spec:
       jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    deprecated: true
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineSet is the Schema for the machinesets API.
+        description: "MachineSet is the Schema for the machinesets API. \n Deprecated:\
+          \ This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/charts/cluster-api-core/templates/deployment-0.yaml
+++ b/charts/cluster-api-core/templates/deployment-0.yaml
@@ -22,7 +22,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=localhost:8080
-        - --feature-gates=MachinePool={{ .Values.exp_machine_pool }},ClusterResourceSet={{ .Values.exp_cluster_resource_set }},ClusterTopology={{ .Values.cluster_topology }},RuntimeSDK={{ .Values.exp_runtime_sdk }}
+        - --feature-gates=MachinePool={{ .Values.exp_machine_pool }},ClusterResourceSet={{ .Values.exp_cluster_resource_set }},ClusterTopology={{ .Values.cluster_topology }},RuntimeSDK={{ .Values.exp_runtime_sdk }},LazyRestmapper={{ .Values.exp_lazy_restmapper }}
         - --logging-format=json
         command:
         - /manager
@@ -57,10 +57,22 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: capi-manager
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/charts/cluster-api-core/templates/validatingwebhookconfiguration-0.yaml
+++ b/charts/cluster-api-core/templates/validatingwebhookconfiguration-0.yaml
@@ -214,6 +214,28 @@ webhooks:
     service:
       name: capi-webhook-service
       namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourcesetbinding
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourcesetbinding.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesetbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
       path: /validate-ipam-cluster-x-k8s-io-v1alpha1-ipaddress
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/charts/cluster-api-core/values.yaml
+++ b/charts/cluster-api-core/values.yaml
@@ -1,5 +1,6 @@
 cluster_topology: false
 exp_cluster_resource_set: false
+exp_lazy_restmapper: false
 exp_machine_pool: false
 exp_runtime_sdk: false
-image: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.2
+image: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.3

--- a/charts/cluster-api-provider-openstack/Chart.yaml
+++ b/charts/cluster-api-provider-openstack/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-provider-openstack
 type: application
-version: v0.1.7
+version: v0.1.8

--- a/charts/cluster-api/Chart.yaml
+++ b/charts/cluster-api/Chart.yaml
@@ -1,24 +1,24 @@
 apiVersion: v2
-appVersion: v1.3.2
+appVersion: v1.4.3
 name: cluster-api
 description: A Helm chart to deploy Cluster API
 type: application
-version: v0.1.7
+version: v0.1.8
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 
 dependencies:
 - name: cluster-api-core
-  version: v0.1.7
+  version: v0.1.8
   repository: file://../cluster-api-core
 - name: cluster-api-bootstrap-kubeadm
-  version: v0.1.7
+  version: v0.1.8
   repository: file://../cluster-api-bootstrap-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-control-plane-kubeadm
-  version: v0.1.7
+  version: v0.1.8
   repository: file://../cluster-api-control-plane-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-provider-openstack
-  version: v0.1.7
+  version: v0.1.8
   repository: file://../cluster-api-provider-openstack
   condition: openstack.enabled

--- a/charts/cluster-api/values.yaml
+++ b/charts/cluster-api/values.yaml
@@ -9,20 +9,23 @@ openstack:
 cluster-api-core:
   cluster_topology: false
   exp_cluster_resource_set: false
+  exp_lazy_restmapper: false
   exp_machine_pool: false
   exp_runtime_sdk: false
-  image: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.2
+  image: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.3
 
 cluster-api-bootstrap-kubeadm:
   exp_kubeadm_bootstrap_format_ignition: false
+  exp_lazy_restmapper: false
   exp_machine_pool: false
-  image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.3.2
+  image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.4.3
   kubeadm_bootstrap_token_ttl: 15m
 
 cluster-api-control-plane-kubeadm:
   cluster_topology: false
   exp_kubeadm_bootstrap_format_ignition: false
-  image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.3.2
+  exp_lazy_restmapper: false
+  image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.4.3
 
 cluster-api-provider-openstack:
   image: k8s.gcr.io/capi-openstack/capi-openstack-controller:v0.7.1


### PR DESCRIPTION
Fixes an issue where auto-scaling machine deployments would always start at 1 replica, and now scale up to the minimum (because why bother when there's no workload right?)