### PR TITLE
Add Verbatim Pool Annotations

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.21
+version: v0.3.22
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -80,6 +80,15 @@ capacity.cluster-autoscaler.kubernetes.io/gpu-count: '{{ $gpu.count }}'
 {{- end }}
 
 {{/*
+Pool name annotations.
+This uses the pool name, un obfuscated to make it easier for external management
+to reason about the cluster.
+*/}}
+{{- define "pool.annotatations" -}}
+pool.{{ .values.labelDomain }}/name: {{ .name }}
+{{- end }}
+
+{{/*
 Workload failure domain.
 */}}
 {{- define "openstack.failureDomain.compute.workload" -}}

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -27,6 +27,7 @@ metadata:
   annotations:
     # Let CAPO do this in its chosen order.
     argocd.argoproj.io/sync-options: Delete=false
+    {{- include "pool.annotatations" $context | nindent 4 }}
     {{- include "openstackcluster.autoscalingAnnotations" $pool | nindent 4 }}
 spec:
   clusterName: {{ include "cluster.name" $ }}
@@ -59,6 +60,7 @@ metadata:
   annotations:
     # Let CAPO do this in its chosen order.
     argocd.argoproj.io/sync-options: Delete=false
+    {{- include "pool.annotatations" $context | nindent 4 }}
 spec:
   template:
     spec:
@@ -92,6 +94,7 @@ metadata:
   annotations:
     # Let CAPO do this in its chosen order.
     argocd.argoproj.io/sync-options: Delete=false
+    {{- include "pool.annotatations" $context | nindent 4 }}
 spec:
   template:
     spec:


### PR DESCRIPTION
Because Argo will refuse to delete old MDs and other resources because CAPO attaches owner references, you may need to do it manually.  Now working out what you should discard and what you should keep with a bunch of SHA hashes obfuscating the process is hard and makes the client require deep knowledge of how the chart works.  We should rather just look to the annotations rather than that other option.