### PR TITLE
Add Labels for Autoscaling

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.23
+version: v0.3.24
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
+++ b/charts/cluster-api-cluster-openstack/templates/_helpers.tpl
@@ -63,7 +63,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Autoscaling annotations
 */}}
 {{- define "openstackcluster.autoscalingAnnotations" -}}
-{{- with $autoscaling := .autoscaling }}
+{{- with $pool := .pool }}
+{{- with $autoscaling := $pool.autoscaling }}
 {{- with $limits := $autoscaling.limits -}}
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: '{{ $limits.minReplicas }}'
 cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: '{{ $limits.maxReplicas }}'
@@ -77,6 +78,8 @@ capacity.cluster-autoscaler.kubernetes.io/gpu-count: '{{ $gpu.count }}'
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
+capacity.cluster-autoscaler.kubernetes.io/labels: {{ include "openstack.nodelabels.workload" . }}
 {{- end }}
 
 {{/*

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -28,7 +28,7 @@ metadata:
     # Let CAPO do this in its chosen order.
     argocd.argoproj.io/sync-options: Delete=false
     {{- include "pool.annotatations" $context | nindent 4 }}
-    {{- include "openstackcluster.autoscalingAnnotations" $pool | nindent 4 }}
+    {{- include "openstackcluster.autoscalingAnnotations" $context | nindent 4 }}
 spec:
   clusterName: {{ include "cluster.name" $ }}
   {{- if not $pool.autoscaling }}


### PR DESCRIPTION
When using label selectors to schedule workloads, and the workload pool has no machines, then it has no idea if a pool can be scheduled on, because all that jazz is in the KCT, and it's just too stupid to look at that.  Instead we have to duplicate the node labels and add them as an annotation on the MD.