### PR TITLE
Change Container Registry Address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Update this for every tagged release.
-CHART_VERSION = v0.1.9
+CHART_VERSION = v0.1.10
 
 # Defines the versions to use for cluster API components.
 CAPI_VERSION = v1.4.3
@@ -40,7 +40,7 @@ cluster-api-control-plane-kubeadm:
 
 .PHONY: cluster-api-provider-openstack
 cluster-api-provider-openstack:
-	$(GENERATE) --chart $@ --version $(CHART_VERSION) --app-version $(CAPO_VERSION) --path https://github.com/kubernetes-sigs/cluster-api-provider-openstack/config/default?ref=${CAPO_VERSION} --image k8s.gcr.io/capi-openstack/capi-openstack-controller:$(CAPO_VERSION)
+	$(GENERATE) --chart $@ --version $(CHART_VERSION) --app-version $(CAPO_VERSION) --path https://github.com/kubernetes-sigs/cluster-api-provider-openstack/config/default?ref=${CAPO_VERSION} --image registry.k8s.io/capi-openstack/capi-openstack-controller:$(CAPO_VERSION)
 
 .PHONY: test
 test:

--- a/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
+++ b/charts/cluster-api-bootstrap-kubeadm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-bootstrap-kubeadm
 type: application
-version: v0.1.9
+version: v0.1.10

--- a/charts/cluster-api-control-plane-kubeadm/Chart.yaml
+++ b/charts/cluster-api-control-plane-kubeadm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-control-plane-kubeadm
 type: application
-version: v0.1.9
+version: v0.1.10

--- a/charts/cluster-api-core/Chart.yaml
+++ b/charts/cluster-api-core/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-core
 type: application
-version: v0.1.9
+version: v0.1.10

--- a/charts/cluster-api-provider-openstack/Chart.yaml
+++ b/charts/cluster-api-provider-openstack/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for deploying cluster API.
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 name: cluster-api-provider-openstack
 type: application
-version: v0.1.9
+version: v0.1.10

--- a/charts/cluster-api-provider-openstack/values.yaml
+++ b/charts/cluster-api-provider-openstack/values.yaml
@@ -1,1 +1,1 @@
-image: k8s.gcr.io/capi-openstack/capi-openstack-controller:v0.8.0
+image: registry.k8s.io/capi-openstack/capi-openstack-controller:v0.8.0

--- a/charts/cluster-api/Chart.yaml
+++ b/charts/cluster-api/Chart.yaml
@@ -3,22 +3,22 @@ appVersion: v1.4.3
 name: cluster-api
 description: A Helm chart to deploy Cluster API
 type: application
-version: v0.1.9
+version: v0.1.10
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png
 
 dependencies:
 - name: cluster-api-core
-  version: v0.1.9
+  version: v0.1.10
   repository: file://../cluster-api-core
 - name: cluster-api-bootstrap-kubeadm
-  version: v0.1.9
+  version: v0.1.10
   repository: file://../cluster-api-bootstrap-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-control-plane-kubeadm
-  version: v0.1.9
+  version: v0.1.10
   repository: file://../cluster-api-control-plane-kubeadm
   condition: kubeadm.enabled
 - name: cluster-api-provider-openstack
-  version: v0.1.9
+  version: v0.1.10
   repository: file://../cluster-api-provider-openstack
   condition: openstack.enabled

--- a/charts/cluster-api/values.yaml
+++ b/charts/cluster-api/values.yaml
@@ -28,4 +28,4 @@ cluster-api-control-plane-kubeadm:
   image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.4.3
 
 cluster-api-provider-openstack:
-  image: k8s.gcr.io/capi-openstack/capi-openstack-controller:v0.8.0
+  image: registry.k8s.io/capi-openstack/capi-openstack-controller:v0.8.0


### PR DESCRIPTION
From k8s.gcr.io to registry.k8s.io, because that's where the new images land, must have had an old development version lying about.