### PR TITLE
initial proposal for baremetal support

### DIFF
--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -54,10 +54,20 @@ spec:
   controlPlaneOmitAvailabilityZone: true
   managedSecurityGroups: true
   allowAllInClusterTraffic: true
+  {{- if not .Values.network.subnetID }}
   nodeCidr: {{ .Values.network.nodeCIDR }}
+  {{- end }}
   {{- if .Values.network.routerID }}
   router:
-    id: {{ .Values.network.baremetal.routerID }}
+    id: {{ .Values.network.routerID }}
+  {{- end }}
+  {{- if .Values.network.networkID }}
+  network:
+    id: {{ .Values.network.networkID }}
+  {{- end }}
+  {{- if .Values.network.subnetID }}
+  subnet:
+    id: {{ .Values.network.subnetID }}
   {{- end }}
   dnsNameservers:
     {{- range .Values.network.dnsNameservers}}

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -55,6 +55,10 @@ spec:
   managedSecurityGroups: true
   allowAllInClusterTraffic: true
   nodeCidr: {{ .Values.network.nodeCIDR }}
+  {{- if .Values.network.routerID }}
+  router:
+    id: {{ .Values.network.baremetal.routerID }}
+  {{- end }}
   dnsNameservers:
     {{- range .Values.network.dnsNameservers}}
     {{- printf "- %s" . | nindent 2 }}

--- a/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/machinehealthcheck.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   clusterName: {{ include "cluster.name" . }}
   maxUnhealthy: 50%
-  nodeStartupTimeout: 10m0s
+  nodeStartupTimeout: 20m0s
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -3,7 +3,7 @@
 
 {{/*
 Helm is a bit crap in that $. doesn't work in an include with a non-global scope.
-To combat this, we build a custom context before handing off to thte template.
+To combat this, we build a custom context before handing off to the template.
 */}}
 {{- $context := dict "name" $name "pool" $pool "values" $values }}
 
@@ -85,12 +85,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if contains $pool.machine.flavor "baremetal" }}
-      ports:
-        - network:
-            name: {{ $.Values.network.baremetal.networkName }}
-          fixedIPs:
-            - subnet:
-                name: {{ $.Values.network.baremetal.subnetName }}
+      configDrive: true
       {{- end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/charts/cluster-api-cluster-openstack/templates/workload.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/workload.yaml
@@ -84,6 +84,14 @@ spec:
           {{- toYaml $metadata | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if contains $pool.machine.flavor "baremetal" }}
+      ports:
+        - network:
+            name: {{ $.Values.network.baremetal.networkName }}
+          fixedIPs:
+            - subnet:
+                name: {{ $.Values.network.baremetal.subnetName }}
+      {{- end }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -100,11 +108,11 @@ spec:
     spec:
       files:
       {{- range $file := $pool.files }}
-      - content: {{ $file.content }}
-        encoding: base64
-        owner: root
-        path: {{ $file.path }}
-        permissions: "0600"
+        - content: {{ $file.content }}
+          encoding: base64
+          owner: root
+          path: {{ $file.path }}
+          permissions: "0600"
       {{- end }}
       joinConfiguration:
         nodeRegistration:

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -342,7 +342,21 @@
                                 },
                                 "dnsNameservers": {
 					"$ref": "#/$defs/nonEmptyIPV4List"
-                                }
+                                },
+                                "baremetal": {
+									"type": "object",
+									"properties": {
+										"routerID": {
+											"type": "string"
+										},
+										"networkName": {
+											"type": "string"
+										},
+										"subnetName": {
+											"type": "string"
+										}
+									}
+								}
 			}
 		}
 	}

--- a/charts/cluster-api-cluster-openstack/values.schema.json
+++ b/charts/cluster-api-cluster-openstack/values.schema.json
@@ -334,29 +334,24 @@
 				"nodeCIDR": {
 					"$ref": "#/$defs/ipv4Prefix"
 				},
-                                "serviceCIDRs": {
-					"$ref": "#/$defs/nonEmptyIPV4PrefixList"
-                                },
-                                "podCIDRs": {
-					"$ref": "#/$defs/nonEmptyIPV4PrefixList"
-                                },
-                                "dnsNameservers": {
-					"$ref": "#/$defs/nonEmptyIPV4List"
-                                },
-                                "baremetal": {
-									"type": "object",
-									"properties": {
-										"routerID": {
-											"type": "string"
-										},
-										"networkName": {
-											"type": "string"
-										},
-										"subnetName": {
-											"type": "string"
-										}
-									}
-								}
+				"serviceCIDRs": {
+	"$ref": "#/$defs/nonEmptyIPV4PrefixList"
+				},
+				"podCIDRs": {
+	"$ref": "#/$defs/nonEmptyIPV4PrefixList"
+				},
+				"dnsNameservers": {
+	"$ref": "#/$defs/nonEmptyIPV4List"
+				},
+				"routerID": {
+					"type:": "string"
+				},
+				"networkID": {
+					"type:": "string"
+				},
+				"subnetID": {
+					"type:": "string"
+				}
 			}
 		}
 	}

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -186,7 +186,11 @@ network:
   dnsNameservers:
   - 8.8.8.8
 
-  baremetal:
-    routerID: ""
-    networkName: "baremetal_network"
-    subnetName: "baremetal_subnet"
+  # Use existing router
+  # routerID:
+  
+  # Use existing network
+  # networkID:
+  
+  # Use existing subnet
+  # subnetID:

--- a/charts/cluster-api-cluster-openstack/values.yaml
+++ b/charts/cluster-api-cluster-openstack/values.yaml
@@ -185,3 +185,8 @@ network:
   # DNS nameservers to use.
   dnsNameservers:
   - 8.8.8.8
+
+  baremetal:
+    routerID: ""
+    networkName: "baremetal_network"
+    subnetName: "baremetal_subnet"


### PR DESCRIPTION
This is an initial proposal for baremetal support.

Based on the old helm chart we used back in the day for spinning up CAPI/CAPO, this should work. The old chart was tested and nodes came up but because of some Startwell funkery, the baremetal network had two routers which was causing a couple issues with node communication. I've not had chance to mess with that today and figured it'd be time better spent writing this up to give us a springboard into baremetal.

Due to the network dickery, I have not had chance to test this chart but the changes match that of the old chart.

Also it needs consideration on how it would integrate with unikorn. It should give us a good starting point to jump in to bare metal for unikorn support.

