### PR TITLE
Inhibit CAPO Scheduling

### DIFF
--- a/charts/cluster-api-cluster-openstack/Chart.yaml
+++ b/charts/cluster-api-cluster-openstack/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster-openstack
 description: A Helm chart to deploy a Kubernetes Cluster
 type: application
-version: v0.3.26
+version: v0.3.27
 icon: https://raw.githubusercontent.com/eschercloudai/helm-cluster-api/main/icons/default.png

--- a/charts/cluster-api-cluster-openstack/templates/cluster.yaml
+++ b/charts/cluster-api-cluster-openstack/templates/cluster.yaml
@@ -51,6 +51,7 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
+  controlPlaneOmitAvailabilityZone: true
   managedSecurityGroups: true
   allowAllInClusterTraffic: true
   nodeCidr: {{ .Values.network.nodeCIDR }}


### PR DESCRIPTION
As it's actually more trouble than it's worth.  Unikorn uses soft-AA rules anyway to provide HA.